### PR TITLE
Switched to other mirror

### DIFF
--- a/urlRewrite.conf
+++ b/urlRewrite.conf
@@ -1,2 +1,2 @@
 http://download.eclipse.org/cbi/updates/aggregator/|https://palladiosimulator.github.io/Palladio-Build-CBIAggregator-Mirror/
-http://download.eclipse.org/|https://ftp.fau.de/eclipse/
+http://download.eclipse.org/|https://ftp-stud.hs-esslingen.de/Mirrors/eclipse/


### PR DESCRIPTION
Our previously used mirror (ftp.fau.de) is not reliable at the moment because of a hardware defect. Therefore, we switch to another mirror.