### PR TITLE
Added new URL of CBI aggregator mirror.

### DIFF
--- a/urlRewrite.conf
+++ b/urlRewrite.conf
@@ -1,2 +1,2 @@
-http://download.eclipse.org/cbi/updates/aggregator/|https://updatesite.palladio-simulator.com/palladio-p2mirror-cbiaggregator/nightly/
+http://download.eclipse.org/cbi/updates/aggregator/headless/|https://updatesite.palladio-simulator.com/palladio-p2mirror-cbiaggregator/nightly/
 http://download.eclipse.org/|https://ftp.fau.de/eclipse/

--- a/urlRewrite.conf
+++ b/urlRewrite.conf
@@ -1,1 +1,2 @@
+http://download.eclipse.org/cbi/updates/aggregator/|https://updatesite.palladio-simulator.com/palladio-p2mirror-cbiaggregator/nightly/
 http://download.eclipse.org/|https://ftp.fau.de/eclipse/


### PR DESCRIPTION
Unfortunately, Eclipse still fails to properly mirror the CBI Aggregator as described in bug [541102](https://bugs.eclipse.org/bugs/show_bug.cgi?id=541102). Therefore, we have to use our custom mirror.